### PR TITLE
Disable Dependency Dashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
       ":automergePatch",
       ":automergeMinor",
       ":automergeDigest",
+      ":disableDependencyDashboard",
       ":prConcurrentLimit10",
       ":prHourlyLimitNone",
       ":renovatePrefix",


### PR DESCRIPTION
https://docs.renovatebot.com/key-concepts/dashboard/

I don't think we need or want this Issue across all our repositories.

**NOTE**: I'm using this PR to put forth my opinion. This is me asking if it others agree, not implementing a change after already seeing that they do.