### PR TITLE
Add vulnerability alerts settings in the shared config

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,5 +21,6 @@
       "enabled": true,
       "labels": ["security"],
       "automerge": true
-    }
+    },
+    "osvVulnerabilityAlerts": true
   }

--- a/default.json
+++ b/default.json
@@ -20,7 +20,15 @@
     "vulnerabilityAlerts": {
       "enabled": true,
       "labels": ["security"],
-      "automerge": true
+      "automerge": true,
+      "groupName": null,
+      "schedule": [],
+      "dependencyDashboardApproval": false,
+      "minimumReleaseAge": null,
+      "commitMessageSuffix": "[SECURITY]",
+      "branchTopic": "renovate/{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+      "prCreation": "immediate",
+      "vulnerabilityFixStrategy": "lowest"
     },
     "osvVulnerabilityAlerts": true
   }

--- a/default.json
+++ b/default.json
@@ -19,10 +19,7 @@
     "platformAutomerge": false,
     "vulnerabilityAlerts": {
       "enabled": true,
-      "minimumReleaseAge": null,
-      "schedule": [],
-      "dependencyDashboardApproval": false,
-      "stabilityDays": 0,
-      "prCreation": "immediate"
+      "labels": ["security"],
+      "automerge": true
     }
   }

--- a/default.json
+++ b/default.json
@@ -16,5 +16,13 @@
       "schedule:daily"
     ],
     "minimumReleaseAge": "5 days",
-    "platformAutomerge": false
+    "platformAutomerge": false,
+    "vulnerabilityAlerts": {
+      "enabled": true,
+      "minimumReleaseAge": null,
+      "schedule": [],
+      "dependencyDashboardApproval": false,
+      "stabilityDays": 0,
+      "prCreation": "immediate"
+    }
   }


### PR DESCRIPTION
Let's try to see if this configuration better helps renovate create PRs for Github Alerts. 
We are also allowing Renovate to source vulnerabilities alerts from OSV which is an experimental option of Renovate.