### PR TITLE
Force update package.json on version update

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,7 @@
     ],
     "minimumReleaseAge": "5 days",
     "platformAutomerge": false,
+    "rangeStrategy": "bump",
     "vulnerabilityAlerts": {
       "enabled": true,
       "labels": ["security"],


### PR DESCRIPTION
When Renovate update a package to a new version, it will not automatically update the package.json if the new version is already included in the range specified in the package.json. It will only update the lockfile to use the latest version.
 I believe it is confusing and I would prefer the package.json to match the lockfile, happy to go with another decision here