### PR TITLE
fix(chore): update audit Gemfile.lock

### DIFF
--- a/renovate-audit/Gemfile.lock
+++ b/renovate-audit/Gemfile.lock
@@ -1,31 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
-    erb (5.0.3)
-    faraday (2.13.1)
+    erb (6.0.1)
+    faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
-    json (2.12.2)
+    json (2.18.0)
     logger (1.7.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    public_suffix (6.0.2)
+    public_suffix (7.0.2)
     rainbow (3.1.1)
-    sawyer (0.9.2)
+    sawyer (0.9.3)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    uri (1.0.3)
+    uri (1.1.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Renovate recently updated `.ruby-version` to v4. In the PR where this
occurred, everything worked:

```
Using 4.0.0 as input from file .ruby-version
...
Installing faraday-retry 2.3.2
```

But in later runs, it now does not work:

```
Using 4.0.0 as input from file .ruby-version
...
faraday-retry-2.3.2 requires ruby version < 4, >= 2.6, which is incompatible
with the current version, 4.0.0
```

I don't know why this would happen suddenly with nothing else changing.
Perhaps there is some caching going on, since the PR run was uncached
and the failing run had a cache.

In any event, updating the gems to versions without this upper bound is
the fix, so I've done that here. I don't know why Renovate hadn't yet
updated those. Perhaps it would if I waited longer.
