### PR TITLE
Group eslint, react, fortawesome, and tanstack packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -91,42 +91,6 @@
         "extends": ["monorepo:tanstack-table"],
         "matchUpdateTypes": ["major"],
         "groupName": "tanstack-table (major) ({{packageFileDir}})"
-      },
-      {
-        "description": "Group tanstack-router packages together for minor/patch",
-        "extends": ["monorepo:tanstack-router"],
-        "matchUpdateTypes": ["minor", "patch", "digest"],
-        "groupName": "tanstack-router"
-      },
-      {
-        "description": "Split tanstack-router major updates by package.json",
-        "extends": ["monorepo:tanstack-router"],
-        "matchUpdateTypes": ["major"],
-        "groupName": "tanstack-router (major) ({{packageFileDir}})"
-      },
-      {
-        "description": "Group tanstack-form packages together for minor/patch",
-        "extends": ["monorepo:tanstack-form"],
-        "matchUpdateTypes": ["minor", "patch", "digest"],
-        "groupName": "tanstack-form"
-      },
-      {
-        "description": "Split tanstack-form major updates by package.json",
-        "extends": ["monorepo:tanstack-form"],
-        "matchUpdateTypes": ["major"],
-        "groupName": "tanstack-form (major) ({{packageFileDir}})"
-      },
-      {
-        "description": "Group tanstack-virtual packages together for minor/patch",
-        "extends": ["monorepo:tanstack-virtual"],
-        "matchUpdateTypes": ["minor", "patch", "digest"],
-        "groupName": "tanstack-virtual"
-      },
-      {
-        "description": "Split tanstack-virtual major updates by package.json",
-        "extends": ["monorepo:tanstack-virtual"],
-        "matchUpdateTypes": ["major"],
-        "groupName": "tanstack-virtual (major) ({{packageFileDir}})"
       }
     ],
     "vulnerabilityAlerts": {

--- a/default.json
+++ b/default.json
@@ -19,6 +19,116 @@
     "minimumReleaseAge": "5 days",
     "platformAutomerge": false,
     "rangeStrategy": "bump",
+    "packageRules": [
+      {
+        "description": "Group eslint packages together for minor/patch",
+        "extends": ["monorepo:eslint"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "eslint"
+      },
+      {
+        "description": "Split eslint major updates by package.json",
+        "extends": ["monorepo:eslint"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "eslint (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group typescript-eslint packages together for minor/patch",
+        "extends": ["monorepo:typescript-eslint"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "typescript-eslint"
+      },
+      {
+        "description": "Split typescript-eslint major updates by package.json",
+        "extends": ["monorepo:typescript-eslint"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "typescript-eslint (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group react packages together for minor/patch",
+        "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom", "@types/react-is"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "react"
+      },
+      {
+        "description": "Split react major updates by package.json",
+        "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom", "@types/react-is"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "react (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group fortawesome packages together for minor/patch",
+        "matchPackageNames": ["@fortawesome/**"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "fortawesome"
+      },
+      {
+        "description": "Split fortawesome major updates by package.json",
+        "matchPackageNames": ["@fortawesome/**"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "fortawesome (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group tanstack-query packages together for minor/patch",
+        "extends": ["monorepo:tanstack-query"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "tanstack-query"
+      },
+      {
+        "description": "Split tanstack-query major updates by package.json",
+        "extends": ["monorepo:tanstack-query"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "tanstack-query (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group tanstack-table packages together for minor/patch",
+        "extends": ["monorepo:tanstack-table"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "tanstack-table"
+      },
+      {
+        "description": "Split tanstack-table major updates by package.json",
+        "extends": ["monorepo:tanstack-table"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "tanstack-table (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group tanstack-router packages together for minor/patch",
+        "extends": ["monorepo:tanstack-router"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "tanstack-router"
+      },
+      {
+        "description": "Split tanstack-router major updates by package.json",
+        "extends": ["monorepo:tanstack-router"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "tanstack-router (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group tanstack-form packages together for minor/patch",
+        "extends": ["monorepo:tanstack-form"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "tanstack-form"
+      },
+      {
+        "description": "Split tanstack-form major updates by package.json",
+        "extends": ["monorepo:tanstack-form"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "tanstack-form (major) ({{packageFileDir}})"
+      },
+      {
+        "description": "Group tanstack-virtual packages together for minor/patch",
+        "extends": ["monorepo:tanstack-virtual"],
+        "matchUpdateTypes": ["minor", "patch", "digest"],
+        "groupName": "tanstack-virtual"
+      },
+      {
+        "description": "Split tanstack-virtual major updates by package.json",
+        "extends": ["monorepo:tanstack-virtual"],
+        "matchUpdateTypes": ["major"],
+        "groupName": "tanstack-virtual (major) ({{packageFileDir}})"
+      }
+    ],
     "vulnerabilityAlerts": {
       "enabled": true,
       "labels": ["security"],


### PR DESCRIPTION
Closing the custom megarepo change: https://github.com/freckle/megarepo/pull/44260
Consensus with the team was the config in this PR: https://illuminate.slack.com/archives/C09PBMUP92R/p1778011484523609?thread_ts=1778002712.890219&cid=C09PBMUP92R

## Summary

- Groups eslint, react, fortawesome, and tanstack packages so minor/patch updates are combined into a single PR across all `package.json` files
- Major updates are split per `package.json` directory (using `{{packageFileDir}}` template) for safer, more isolated upgrades
- Leverages existing Renovate monorepo presets where available (`monorepo:eslint`, `monorepo:typescript-eslint`, `monorepo:tanstack-query`, `monorepo:tanstack-table`) and `matchPackageNames` for react and `@fortawesome/**`

## Behavior

| Package group | Minor/Patch | Major |
|---|---|---|
| eslint | Single PR across all package.json | Separate PR per package.json |
| typescript-eslint | Single PR across all package.json | Separate PR per package.json |
| react + @types/react | Single PR across all package.json | Separate PR per package.json |
| @fortawesome/** | Single PR across all package.json | Separate PR per package.json |
| tanstack-query | Single PR across all package.json | Separate PR per package.json |
| tanstack-table | Single PR across all package.json | Separate PR per package.json |

## Test plan

- [ ] Renovate dry-run or debug log confirms correct grouping on a repo with multiple package.json files
- [ ] Minor/patch updates for grouped packages appear as a single PR
- [ ] Major updates create per-directory PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)